### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ self.helper.compressVideo(url, outputURL: self.cameraManager.tempCompressFilePat
 
 ## Support
 
-Supports iOS8 and above. XCode 7.0 is required to build the latest code written in Swift 2.0
+Supports iOS8 and above. Xcode 7.0 is required to build the latest code written in Swift 2.0
 
 ## Author
 


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
